### PR TITLE
Additional export options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ When listing an export file path, specify the desired output type at the end, su
 - [x] locres (as json)
 - [x] js (as js)
 - [x] db (as db)
+- [x] upluginmanifest, uproject, manifest, uplugin, archive, vmodule, verse, html, json, ini, txt, log, bat, dat, cfg, ide, ipl, zon, xml, css, csv, pem, tps, lua, po, h (as their respective type)
 - [ ] everything else
 
 ## [Usage](#usage)
@@ -138,3 +139,6 @@ The exporter should now be able to detect the game files.
 
 ### How to fix no files loading due to incorrect AES key
 If you have the wrong AES key, refer to [this guide](https://github.com/Cracko298/UE4-AES-Key-Extracting-Guide) or [this tool (untested)](https://github.com/mmozeiko/aes-finder) to get the correct key.
+
+
+upluginmanifest, uproject, manifest, uplugin, archive, vmodule, verse, html, json, ini, txt, log, bat, dat, cfg, ide, ipl, zon, xml, css, csv, pem, tps, lua, po, h

--- a/README.md
+++ b/README.md
@@ -139,6 +139,3 @@ The exporter should now be able to detect the game files.
 
 ### How to fix no files loading due to incorrect AES key
 If you have the wrong AES key, refer to [this guide](https://github.com/Cracko298/UE4-AES-Key-Extracting-Guide) or [this tool (untested)](https://github.com/mmozeiko/aes-finder) to get the correct key.
-
-
-upluginmanifest, uproject, manifest, uplugin, archive, vmodule, verse, html, json, ini, txt, log, bat, dat, cfg, ide, ipl, zon, xml, css, csv, pem, tps, lua, po, h

--- a/UnrealExporter/Program.cs
+++ b/UnrealExporter/Program.cs
@@ -582,6 +582,44 @@ public class UnrealExporter
                                 }
                                 break;
                             }
+                        case "upluginmanifest":
+                        case "uproject":
+                        case "manifest":
+                        case "uplugin":
+                        case "archive":
+                        case "vmodule":
+                        case "verse":
+                        case "html":
+                        case "json":
+                        case "ini":
+                        case "txt":
+                        case "log":
+                        case "bat":
+                        case "dat":
+                        case "cfg":
+                        case "ide":
+                        case "ipl":
+                        case "zon":
+                        case "xml":
+                        case "css":
+                        case "csv":
+                        case "pem":
+                        case "tps":
+                        case "lua":
+                        case "po":
+                        case "h":
+                        {
+                            if (outputType == fileType && provider.TrySaveAsset(file.Value.Path, out var data))
+                            {
+                                if (config.LogOutputs) Console.WriteLine("=> " + outputPath + "." + outputType);
+                                using var stream = new MemoryStream(data) { Position = 0 };
+                                using var reader = new StreamReader(stream);
+                                if (!Directory.Exists(outputDir)) Directory.CreateDirectory(outputDir);
+                                File.WriteAllText(outputPath + "." + outputType, reader.ReadToEnd());
+                                Interlocked.Increment(ref totalExportedFiles);
+                            }
+                            break;
+                        }
                         case "db":
                             {
                                 if (outputType == fileType && provider.TrySaveAsset(file.Value.Path, out var data))


### PR DESCRIPTION
Adds export for the following types: 
upluginmanifest, uproject, manifest, uplugin, archive, vmodule, verse, html, json, ini, txt, log, bat, dat, cfg, ide, ipl, zon, xml, css, csv, pem, tps, lua, po, h

Files can be exported as the same type as they're. For example: '/Game/Content/Path/To/Config.ini:ini'